### PR TITLE
feat: add log button on main screen

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -364,6 +364,20 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             }
         });
 
+        Button btnLog = findViewById(R.id.btnLog);
+        btnLog.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (Util.canFilter(ActivityMain.this))
+                    if (IAB.isPurchased(ActivityPro.SKU_LOG, ActivityMain.this))
+                        startActivity(new Intent(ActivityMain.this, ActivityLog.class));
+                    else
+                        startActivity(new Intent(ActivityMain.this, ActivityPro.class));
+                else
+                    Toast.makeText(ActivityMain.this, R.string.msg_unavailable, Toast.LENGTH_SHORT).show();
+            }
+        });
+
         showHints();
 
         // Listen for preference changes

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -40,6 +40,14 @@
             android:textColor="?attr/colorOff"
             android:visibility="visible" />
 
+        <Button
+            android:id="@+id/btnLog"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="@string/menu_log"
+            android:textAppearance="@style/TextSmall" />
+
         <LinearLayout
             android:id="@+id/llUsage"
             android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- add "Show log" button to main screen layout
- wire button to open connection log or upsell if unavailable

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a730e106bc8320a449b14f5f8e32e7