### PR TITLE
Fix AndroidX config and manifest for connectionlogger

### DIFF
--- a/connectionlogger/app/src/main/AndroidManifest.xml
+++ b/connectionlogger/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.connectionlogger">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BIND_VPN_SERVICE" />
@@ -18,7 +17,7 @@
             </intent-filter>
         </service>
 
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/connectionlogger/gradle.properties
+++ b/connectionlogger/gradle.properties
@@ -1,0 +1,9 @@
+org.gradle.jvmargs=-Xmx500m
+android.enableD8=true
+android.useAndroidX=true
+android.enableJetifier=true
+android.enableR8.fullMode=false
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false
+android.suppressUnsupportedCompileSdk=35


### PR DESCRIPTION
## Summary
- enable AndroidX and related build flags for connectionlogger module
- remove obsolete package declaration and explicitly export MainActivity

## Testing
- `./gradlew -p connectionlogger app:assembleDebug` *(fails: Could not resolve dependencies, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bb575ad75083209f54dd11bff8d8a1