### PR TITLE
Fix manifest tag in ConnectionLogger module

### DIFF
--- a/connectionlogger/app/src/main/AndroidManifest.xml
+++ b/connectionlogger/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BIND_VPN_SERVICE" />


### PR DESCRIPTION
## Summary
- close root `<manifest>` tag in ConnectionLogger app's manifest

## Testing
- `./gradlew -p connectionlogger app:assembleDebug` *(fails: Could not resolve dependencies, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bb584080908320a080ad32ebf16180