### PR TITLE
feat: add connectionlogger UI

### DIFF
--- a/connectionlogger/README.md
+++ b/connectionlogger/README.md
@@ -1,0 +1,35 @@
+# ConnectionLogger
+
+ConnectionLogger 是一個示範專案，展示如何以 NetGuard 的 VPN 引擎擷取並記錄裝置上的所有網路連線。
+
+## 流程概述
+
+1. `MainActivity` 啟動後立即啟動 `ConnectionLoggerService`。
+2. `ConnectionLoggerService` 擴充自 Android `VpnService`，在 `onStartCommand` 中：
+   - 透過 JNI 載入 `libnetguard` 原生程式庫並呼叫 `jni_init` 建立原生 context。
+   - 使用 `VpnService.Builder` 建立虛擬的 TUN 介面，設定位址和路由。
+   - 成功建立 TUN 後，呼叫 `jni_start` 啟動記錄器，接著以檔案描述符與 `jni_run` 執行事件迴圈。
+   - 原生層透過回呼 `usage(Usage)` 與 `log(Packet, int, boolean)` 回報流量統計與封包詳細資料，並寫入 Android 的 `Logcat`。
+3. 服務被停止時，會依序呼叫 `jni_stop` 與 `jni_clear` 釋放資源。
+
+## 主要功能
+
+- 建立僅供記錄用途的 VPN 連線，所有流量會被導向使用者空間。
+- 利用 NetGuard 的原生程式庫解析 TCP、UDP、DNS 等協定，並將每個封包及連線狀態透過 Java 回呼輸出。
+- 示範如何在 Android 應用程式中整合 C/C++ 原生程式碼（透過 CMake 與 NDK）。
+
+## 建置
+
+在專案根目錄執行：
+
+```
+./gradlew -p connectionlogger assembleDebug
+```
+
+即可編譯出 `ConnectionLogger` 的 APK，過程中會同時編譯 `app/src/main/jni/netguard` 底下的原生程式碼。
+
+## 目錄結構
+
+- `app/src/main/java/com/example/connectionlogger` – Java 入口點與服務。
+- `app/src/main/jni/netguard` – 來自 NetGuard 的原生程式庫。
+- `app/src/main/res` – 介面與資源檔案。

--- a/connectionlogger/app/src/main/java/com/example/connectionlogger/ConnectionLoggerService.java
+++ b/connectionlogger/app/src/main/java/com/example/connectionlogger/ConnectionLoggerService.java
@@ -6,6 +6,8 @@ import android.os.ParcelFileDescriptor;
 import android.util.Log;
 
 public class ConnectionLoggerService extends VpnService {
+    public static final String ACTION_LOG = "com.example.connectionlogger.LOG";
+    public static final String EXTRA_MESSAGE = "message";
     static {
         System.loadLibrary("netguard");
     }
@@ -53,11 +55,19 @@ public class ConnectionLoggerService extends VpnService {
 
     // Callbacks from native layer
     public void usage(Usage usage) {
-        Log.i("ConnectionLogger", "usage: " + usage);
+        String msg = "usage: " + usage;
+        Log.i("ConnectionLogger", msg);
+        Intent intent = new Intent(ACTION_LOG);
+        intent.putExtra(EXTRA_MESSAGE, msg);
+        sendBroadcast(intent);
     }
 
     public void log(Packet packet, int connection, boolean interactive) {
-        Log.i("ConnectionLogger", "packet=" + packet + " connection=" + connection + " interactive=" + interactive);
+        String msg = "packet=" + packet + " connection=" + connection + " interactive=" + interactive;
+        Log.i("ConnectionLogger", msg);
+        Intent intent = new Intent(ACTION_LOG);
+        intent.putExtra(EXTRA_MESSAGE, msg);
+        sendBroadcast(intent);
     }
 
     public static class Usage {

--- a/connectionlogger/app/src/main/java/com/example/connectionlogger/MainActivity.java
+++ b/connectionlogger/app/src/main/java/com/example/connectionlogger/MainActivity.java
@@ -1,14 +1,38 @@
 package com.example.connectionlogger;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
+import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class MainActivity extends AppCompatActivity {
+    private TextView logView;
+
+    private final BroadcastReceiver logReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String msg = intent.getStringExtra(ConnectionLoggerService.EXTRA_MESSAGE);
+            if (msg != null) {
+                logView.append(msg + "\n");
+            }
+        }
+    };
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        logView = findViewById(R.id.logs);
+        registerReceiver(logReceiver, new IntentFilter(ConnectionLoggerService.ACTION_LOG));
         startService(new Intent(this, ConnectionLoggerService.class));
+    }
+
+    @Override
+    protected void onDestroy() {
+        unregisterReceiver(logReceiver);
+        super.onDestroy();
     }
 }

--- a/connectionlogger/app/src/main/res/layout/activity_main.xml
+++ b/connectionlogger/app/src/main/res/layout/activity_main.xml
@@ -2,12 +2,18 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
     android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Connection Logger" />
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/logs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:fontFamily="monospace" />
+    </ScrollView>
 </LinearLayout>


### PR DESCRIPTION
## Summary
- document ConnectionLogger module and its flow
- display usage and packet logs in a scrollable UI via broadcast intents

## Testing
- `./gradlew -p connectionlogger assembleDebug` *(fails: Could not resolve dependencies, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9761afe883209846e7c6f1340e43