### PR TITLE
Add Chinese comments to connection logger

### DIFF
--- a/connectionlogger/app/src/main/java/com/example/connectionlogger/ConnectionLoggerService.java
+++ b/connectionlogger/app/src/main/java/com/example/connectionlogger/ConnectionLoggerService.java
@@ -5,13 +5,17 @@ import android.net.VpnService;
 import android.os.ParcelFileDescriptor;
 import android.util.Log;
 
+// 透過 VPNService 監聽並紀錄網路連線的背景服務
 public class ConnectionLoggerService extends VpnService {
+    // 廣播動作與附加訊息鍵值
     public static final String ACTION_LOG = "com.example.connectionlogger.LOG";
     public static final String EXTRA_MESSAGE = "message";
     static {
+        // 載入原生函式庫
         System.loadLibrary("netguard");
     }
 
+    // 與原生層互動的函式宣告
     private native long jni_init(int sdk);
     private native void jni_start(long context, int loglevel);
     private native void jni_run(long context, int tun, boolean fwd53, int rcode);
@@ -19,11 +23,13 @@ public class ConnectionLoggerService extends VpnService {
     private native void jni_clear(long context);
     private native int[] jni_get_stats(long context);
 
+    // 保存原生層回傳的操作代號
     private long handle;
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         if (handle == 0) {
+            // 初始化原生層並建立 TUN 介面
             handle = jni_init(android.os.Build.VERSION.SDK_INT);
             Builder builder = new Builder();
             builder.addAddress("10.1.10.1", 32);
@@ -31,21 +37,25 @@ public class ConnectionLoggerService extends VpnService {
             try {
                 ParcelFileDescriptor pfd = builder.establish();
                 if (pfd != null) {
+                    // 開始並運行記錄服務
                     jni_start(handle, 0);
                     jni_run(handle, pfd.getFd(), true, 0);
                 } else {
+                    // 建立 TUN 失敗
                     Log.e("ConnectionLogger", "Failed to establish TUN");
                 }
             } catch (Exception ex) {
                 Log.e("ConnectionLogger", "Error starting VPN", ex);
             }
         }
+        // 若服務被系統終止，嘗試重啟
         return START_STICKY;
     }
 
     @Override
     public void onDestroy() {
         if (handle != 0) {
+            // 停止原生層並清理資源
             jni_stop(handle);
             jni_clear(handle);
             handle = 0;
@@ -53,7 +63,7 @@ public class ConnectionLoggerService extends VpnService {
         super.onDestroy();
     }
 
-    // Callbacks from native layer
+    // 以下為原生層回呼
     public void usage(Usage usage) {
         String msg = "usage: " + usage;
         Log.i("ConnectionLogger", msg);
@@ -70,6 +80,7 @@ public class ConnectionLoggerService extends VpnService {
         sendBroadcast(intent);
     }
 
+    // 使用量資訊模型
     public static class Usage {
         @Override
         public String toString() {
@@ -77,6 +88,7 @@ public class ConnectionLoggerService extends VpnService {
         }
     }
 
+    // 封包資訊模型
     public static class Packet {
         @Override
         public String toString() {

--- a/connectionlogger/app/src/main/java/com/example/connectionlogger/MainActivity.java
+++ b/connectionlogger/app/src/main/java/com/example/connectionlogger/MainActivity.java
@@ -8,14 +8,19 @@ import android.os.Bundle;
 import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 
+// 主介面活動，負責顯示從服務傳來的連線日誌
 public class MainActivity extends AppCompatActivity {
+    // 用於顯示日誌文字的視圖
     private TextView logView;
 
+    // 接收 ConnectionLoggerService 廣播的接收器
     private final BroadcastReceiver logReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
+            // 取得服務發送的日誌訊息
             String msg = intent.getStringExtra(ConnectionLoggerService.EXTRA_MESSAGE);
             if (msg != null) {
+                // 將日誌訊息顯示在畫面上
                 logView.append(msg + "\n");
             }
         }
@@ -25,13 +30,16 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        logView = findViewById(R.id.logs);
+        logView = findViewById(R.id.logs); // 取得日誌顯示區域
+        // 註冊接收器以接收來自服務的日誌廣播
         registerReceiver(logReceiver, new IntentFilter(ConnectionLoggerService.ACTION_LOG));
+        // 啟動連線記錄服務
         startService(new Intent(this, ConnectionLoggerService.class));
     }
 
     @Override
     protected void onDestroy() {
+        // 活動銷毀時取消註冊接收器以避免洩漏
         unregisterReceiver(logReceiver);
         super.onDestroy();
     }


### PR DESCRIPTION
## Summary
- document connection logger service and activity with Chinese comments

## Testing
- `./gradlew :connectionlogger:app:assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd963132a48320aadd57d408b22a85