### PR TITLE
Add NetGuard classes to connectionlogger

### DIFF
--- a/connectionlogger/app/src/main/java/com/example/connectionlogger/ConnectionLoggerService.java
+++ b/connectionlogger/app/src/main/java/com/example/connectionlogger/ConnectionLoggerService.java
@@ -5,6 +5,9 @@ import android.net.VpnService;
 import android.os.ParcelFileDescriptor;
 import android.util.Log;
 
+import eu.faircode.netguard.Packet;
+import eu.faircode.netguard.Usage;
+
 // 透過 VPNService 監聽並紀錄網路連線的背景服務
 public class ConnectionLoggerService extends VpnService {
     // 廣播動作與附加訊息鍵值
@@ -78,21 +81,5 @@ public class ConnectionLoggerService extends VpnService {
         Intent intent = new Intent(ACTION_LOG);
         intent.putExtra(EXTRA_MESSAGE, msg);
         sendBroadcast(intent);
-    }
-
-    // 使用量資訊模型
-    public static class Usage {
-        @Override
-        public String toString() {
-            return "Usage{}";
-        }
-    }
-
-    // 封包資訊模型
-    public static class Packet {
-        @Override
-        public String toString() {
-            return "Packet{}";
-        }
     }
 }

--- a/connectionlogger/app/src/main/java/eu/faircode/netguard/Allowed.java
+++ b/connectionlogger/app/src/main/java/eu/faircode/netguard/Allowed.java
@@ -1,0 +1,35 @@
+package eu.faircode.netguard;
+
+/*
+    This file is part of NetGuard.
+
+    NetGuard is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    NetGuard is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2015-2024 by Marcel Bokhorst (M66B)
+*/
+
+public class Allowed {
+    public String raddr;
+    public int rport;
+
+    public Allowed() {
+        this.raddr = null;
+        this.rport = 0;
+    }
+
+    public Allowed(String raddr, int rport) {
+        this.raddr = raddr;
+        this.rport = rport;
+    }
+}

--- a/connectionlogger/app/src/main/java/eu/faircode/netguard/Packet.java
+++ b/connectionlogger/app/src/main/java/eu/faircode/netguard/Packet.java
@@ -1,0 +1,42 @@
+package eu.faircode.netguard;
+
+/*
+    This file is part of NetGuard.
+
+    NetGuard is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    NetGuard is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2015-2024 by Marcel Bokhorst (M66B)
+*/
+
+public class Packet {
+    public long time;
+    public int version;
+    public int protocol;
+    public String flags;
+    public String saddr;
+    public int sport;
+    public String daddr;
+    public int dport;
+    public String data;
+    public int uid;
+    public boolean allowed;
+
+    public Packet() {
+    }
+
+    @Override
+    public String toString() {
+        return "uid=" + uid + " v" + version + " p" + protocol + " " + daddr + "/" + dport;
+    }
+}

--- a/connectionlogger/app/src/main/java/eu/faircode/netguard/ResourceRecord.java
+++ b/connectionlogger/app/src/main/java/eu/faircode/netguard/ResourceRecord.java
@@ -1,0 +1,49 @@
+package eu.faircode.netguard;
+
+/*
+    This file is part of NetGuard.
+
+    NetGuard is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    NetGuard is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2015-2024 by Marcel Bokhorst (M66B)
+*/
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class ResourceRecord {
+    public long Time;
+    public String QName;
+    public String AName;
+    public String Resource;
+    public int TTL;
+    public int uid;
+
+    private static DateFormat formatter = SimpleDateFormat.getDateTimeInstance();
+
+    public ResourceRecord() {
+    }
+
+    @Override
+    public String toString() {
+        return formatter.format(new Date(Time).getTime()) +
+                " Q " + QName +
+                " A " + AName +
+                " R " + Resource +
+                " TTL " + TTL +
+                " uid " + uid +
+                " " + formatter.format(new Date(Time + TTL * 1000L).getTime());
+    }
+}

--- a/connectionlogger/app/src/main/java/eu/faircode/netguard/Usage.java
+++ b/connectionlogger/app/src/main/java/eu/faircode/netguard/Usage.java
@@ -1,0 +1,46 @@
+package eu.faircode.netguard;
+
+/*
+    This file is part of NetGuard.
+
+    NetGuard is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    NetGuard is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2015-2024 by Marcel Bokhorst (M66B)
+*/
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class Usage {
+    public long Time;
+    public int Version;
+    public int Protocol;
+    public String DAddr;
+    public int DPort;
+    public int Uid;
+    public long Sent;
+    public long Received;
+
+    private static DateFormat formatter = SimpleDateFormat.getDateTimeInstance();
+
+    @Override
+    public String toString() {
+        return formatter.format(new Date(Time).getTime()) +
+                " v" + Version + " p" + Protocol +
+                " " + DAddr + "/" + DPort +
+                " uid " + Uid +
+                " out " + Sent + " in " + Received;
+    }
+}


### PR DESCRIPTION
## Summary
- include NetGuard packet, allowed, resource record and usage classes in the connectionlogger app
- update `ConnectionLoggerService` to use NetGuard packet and usage models from the new package

## Testing
- `./gradlew -p connectionlogger build` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20-RC2, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb68fae008320b5dd33d1a0adba4e