### PR TITLE
Add RecyclerView dependency for connection logger

### DIFF
--- a/connectionlogger/app/build.gradle
+++ b/connectionlogger/app/build.gradle
@@ -42,4 +42,5 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
 }


### PR DESCRIPTION
## Summary
- include AndroidX RecyclerView library in connectionlogger module

## Testing
- `./gradlew -p connectionlogger assembleDebug` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-stdlib-jdk8:403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bed19ab8b883209eefe3b523d3361b