### PR TITLE
fix: ensure connection logger broadcasts reach activity

### DIFF
--- a/connectionlogger/app/src/main/java/com/example/connectionlogger/ConnectionLoggerService.java
+++ b/connectionlogger/app/src/main/java/com/example/connectionlogger/ConnectionLoggerService.java
@@ -89,6 +89,7 @@ public class ConnectionLoggerService extends VpnService {
         String msg = "usage: " + usage;
         Log.i("ConnectionLogger", msg);
         Intent intent = new Intent(ACTION_LOG);
+        intent.setPackage(getPackageName());
         intent.putExtra(EXTRA_MESSAGE, msg);
         sendBroadcast(intent);
     }
@@ -97,6 +98,7 @@ public class ConnectionLoggerService extends VpnService {
         String msg = "packet=" + packet + " connection=" + connection + " interactive=" + interactive;
         Log.i("ConnectionLogger", msg);
         Intent intent = new Intent(ACTION_LOG);
+        intent.setPackage(getPackageName());
         intent.putExtra(EXTRA_MESSAGE, msg);
         sendBroadcast(intent);
     }
@@ -129,6 +131,7 @@ public class ConnectionLoggerService extends VpnService {
         String msg = "allow " + packet;
         Log.i("ConnectionLogger", msg);
         Intent intent = new Intent(ACTION_LOG);
+        intent.setPackage(getPackageName());
         intent.putExtra(EXTRA_MESSAGE, msg);
         sendBroadcast(intent);
 


### PR DESCRIPTION
## Summary
- make ConnectionLoggerService broadcasts explicit so MainActivity receives them

## Testing
- `./gradlew -p connectionlogger test` *(fails: Could not resolve dependencies, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bed41e76a48320bfdc31a1765f8e92