### PR TITLE
Use reflection for setLocalTrafficAllowed call

### DIFF
--- a/connectionlogger/app/src/main/java/com/example/connectionlogger/ConnectionLoggerService.java
+++ b/connectionlogger/app/src/main/java/com/example/connectionlogger/ConnectionLoggerService.java
@@ -53,8 +53,16 @@ public class ConnectionLoggerService extends VpnService {
             // 攔截常見區域網段
             builder.addRoute("192.168.0.0", 16);
             // 從 Android 13 開始讓本地流量也走 VPN
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
-                builder.setLocalTrafficAllowed(false);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                try {
+                    // 使用反射以維持舊版 API 的相容性
+                    VpnService.Builder.class
+                            .getMethod("setLocalTrafficAllowed", boolean.class)
+                            .invoke(builder, false);
+                } catch (Exception ex) {
+                    Log.w("ConnectionLogger", "setLocalTrafficAllowed unavailable", ex);
+                }
+            }
             try {
                 ParcelFileDescriptor pfd = builder.establish();
                 if (pfd != null) {


### PR DESCRIPTION
## Summary
- Handle Android 13 `setLocalTrafficAllowed` via reflection to keep compatibility on older compile SDKs

## Testing
- `./gradlew -p connectionlogger app:assembleDebug` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20-RC2... status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bed9fb1d548320810f438439a50f11